### PR TITLE
[FIX] l10n_es_aeat_sii - corrección en DesgloseTipoOperacion/Prestaci…

### DIFF
--- a/l10n_es_aeat_sii/models/account_invoice.py
+++ b/l10n_es_aeat_sii/models/account_invoice.py
@@ -527,10 +527,9 @@ class AccountInvoice(models.Model):
                         type_breakdown['PrestacionServicios'].setdefault(
                             'Sujeta', {}
                         )
-                    service_dict = type_breakdown[
-                        'PrestacionServicios']['Sujeta']
+                    service_dict = type_breakdown['PrestacionServicios']
                     if tax_line in taxes_sfesse:
-                        service_dict = service_dict.setdefault(
+                        service_dict = service_dict['Sujeta'].setdefault(
                             'Exenta',
                             {'DetalleExenta': []})
                         det_dict = {'BaseImponible':


### PR DESCRIPTION
…onServicios/Sujeta: si el impuesto es por servicios, sujeto y no exento el diccionario se generaba mal --> error